### PR TITLE
Resolve runtime error when inserting empty strings into plugginSetting

### DIFF
--- a/src/main/java/com/monitorjbl/plugins/config/ConfigDao.java
+++ b/src/main/java/com/monitorjbl/plugins/config/ConfigDao.java
@@ -70,16 +70,16 @@ public class ConfigDao {
   @SuppressWarnings("unchecked")
   void writeConfig(PluginSettings settings, Config config) {
     settings.put(REQUIRED_REVIEWS, toString(config.getRequiredReviews()));
-    settings.put(REQUIRED_REVIWERS, join(config.getRequiredReviewers(), new FilterInvalidUsers()));
-    settings.put(REQUIRED_REVIWER_GROUPS, join(config.getRequiredReviewerGroups(), new FilterInvalidGroups()));
-    settings.put(DEFAULT_REVIEWERS, join(config.getDefaultReviewers(), new FilterInvalidUsers()));
-    settings.put(DEFAULT_REVIEWER_GROUPS, join(config.getDefaultReviewerGroups(), new FilterInvalidGroups()));
-    settings.put(EXCLUDED_USERS, join(config.getExcludedUsers(), new FilterInvalidUsers()));
-    settings.put(EXCLUDED_GROUPS, join(config.getExcludedGroups(), new FilterInvalidGroups()));
-    settings.put(BLOCKED_COMMITS, join(config.getBlockedCommits(), noOpFilter));
-    settings.put(BLOCKED_PRS, join(config.getBlockedPRs(), noOpFilter));
-    settings.put(AUTOMERGE_PRS, join(config.getAutomergePRs(), noOpFilter));
-    settings.put(AUTOMERGE_PRS_FROM, join(config.getAutomergePRsFrom(), noOpFilter));
+    settings.put(REQUIRED_REVIWERS, empty2null(join(config.getRequiredReviewers(), new FilterInvalidUsers())));
+    settings.put(REQUIRED_REVIWER_GROUPS, empty2null(join(config.getRequiredReviewerGroups(), new FilterInvalidGroups())));
+    settings.put(DEFAULT_REVIEWERS, empty2null(join(config.getDefaultReviewers(), new FilterInvalidUsers())));
+    settings.put(DEFAULT_REVIEWER_GROUPS, empty2null(join(config.getDefaultReviewerGroups(), new FilterInvalidGroups())));
+    settings.put(EXCLUDED_USERS, empty2null(join(config.getExcludedUsers(), new FilterInvalidUsers())));
+    settings.put(EXCLUDED_GROUPS, empty2null(join(config.getExcludedGroups(), new FilterInvalidGroups())));
+    settings.put(BLOCKED_COMMITS, empty2null(join(config.getBlockedCommits(), noOpFilter)));
+    settings.put(BLOCKED_PRS, empty2null(join(config.getBlockedPRs(), noOpFilter)));
+    settings.put(AUTOMERGE_PRS, empty2null(join(config.getAutomergePRs(), noOpFilter)));
+    settings.put(AUTOMERGE_PRS_FROM, empty2null(join(config.getAutomergePRsFrom(), noOpFilter)));
   }
 
   /**
@@ -143,6 +143,16 @@ public class ConfigDao {
 
   Integer parseInt(String str) {
     return str == null ? null : Integer.parseInt(str);
+  }
+
+  /**
+   * Force empty strings to NULL. In SAL prior to v3.0.5, empty strings behaved as
+   * NULL and removed the item from the settings.  In v3.05, empty strings now cause 
+   * runtime errors with the REST server complaining that settings may not be blank.
+   * See: https://answers.atlassian.com/questions/32510704/should-pluginsettings.put-accept-blank-strings
+   */
+  String empty2null(String string) {
+    return string.isEmpty() ? null : string;
   }
 
   String toString(Integer integer) {


### PR DESCRIPTION
This resolves issues related to a change in how the atlassian SAL processed empty strings for plugginSettings.  Prior to the last release (v3.0.5) an empty string behaved as a NULL and removed the setting.  In v3.0.5 an empty string now generates a runtime error which states that settings may not be blank.

Connected to #26 
