### PR TITLE
Fix issue #24 …

### DIFF
--- a/src/main/resources/pr-create-hook.js
+++ b/src/main/resources/pr-create-hook.js
@@ -116,7 +116,7 @@ define('suggested-reviewers', [
     var target = getTarget();
     AJS.log('Fetching required users');
     $.ajax({
-      url: root + '/rest/pr-harmony/1.0/users/' + target.project.key + '/' + target.name,
+      url: root + '/rest/pr-harmony/1.0/users/' + target.project.key + '/' + target.slug,
       dataType: "json",
       success: function (data) {
         AJS.log('Loaded required users');


### PR DESCRIPTION
Repo names that had caps in them would not pull through users when creating a pull request. I have tested this is working on stash v3.8.1. I originally branched for this fix from tag v1.8.
