### PR TITLE
Use userDisplayName instead of userNames

### DIFF
--- a/src/main/java/com/monitorjbl/plugins/MergeBlocker.java
+++ b/src/main/java/com/monitorjbl/plugins/MergeBlocker.java
@@ -34,9 +34,9 @@ public class MergeBlocker implements MergeRequestCheck {
     } else {
       PullRequestApproval approval = new PullRequestApproval(config, userUtils);
       if (!approval.isPullRequestApproved(pr)) {
-        Set<String> missing = approval.missingRevieiwers(pr);
+        Set<String> missing = approval.missingRevieiwersNames(pr);
         mergeRequest.veto("Required reviewers must approve", (config.getRequiredReviews() - approval.seenReviewers(pr).size()) +
-            " more approvals required from the following users: " + Joiner.on(',').join(missing));
+            " more approvals required from the following users: " + Joiner.on(", ").join(missing));
       }
     }
   }

--- a/src/main/java/com/monitorjbl/plugins/PullRequestApproval.java
+++ b/src/main/java/com/monitorjbl/plugins/PullRequestApproval.java
@@ -41,6 +41,18 @@ public class PullRequestApproval {
     return missingReviewers;
   }
 
+  public Set<String> missingRevieiwersNames(PullRequest pr) {
+    Map<String, PullRequestParticipant> map = transformReviewers(pr);
+    Set<String> missingReviewers = newHashSet();
+    
+    for(String req : concat(config.getRequiredReviewers(), utils.dereferenceGroups(config.getRequiredReviewerGroups()))) {
+       if(reviewerIsMissing(map.get(req)) && !(submitterIsRequiredReviewer(pr, req) && exactlyEnoughRequiredReviewers())) {
+	      missingReviewers.add(utils.getUserDisplayNameByName(req));
+	   }
+	}
+	return missingReviewers;
+  }
+  
   public Set<String> seenReviewers(PullRequest pr) {
     Set<String> required = newHashSet(concat(config.getRequiredReviewers(), utils.dereferenceGroups(config.getRequiredReviewerGroups())));
     return difference(required, missingRevieiwers(pr));

--- a/src/main/java/com/monitorjbl/plugins/UserUtils.java
+++ b/src/main/java/com/monitorjbl/plugins/UserUtils.java
@@ -35,6 +35,11 @@ public class UserUtils {
     return user == null ? Optional.empty() : Optional.of(new User(user.getName(), user.getDisplayName()));
   }
 
+  public String getUserDisplayNameByName(String username) {
+	    ApplicationUser user = userService.getUserByName(username);  
+	    return user.getDisplayName() == null ? username : user.getDisplayName();
+  }
+  
   public ApplicationUser getApplicationUserByName(String username) {
     return userService.getUserByName(username);
   }

--- a/src/test/java/com/monitorjbl/plugins/MergeBlockerTest.java
+++ b/src/test/java/com/monitorjbl/plugins/MergeBlockerTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Set;
@@ -63,6 +64,8 @@ public class MergeBlockerTest {
     when(userUtils.dereferenceGroups(anyList())).thenReturn(Lists.<String>newArrayList());
     when(regexUtils.match(anyList(), anyString())).thenCallRealMethod();
     when(regexUtils.formatBranchName(anyString())).thenCallRealMethod();
+    when(userUtils.getUserDisplayNameByName(Mockito.eq("user1"))).thenReturn("First user");
+    when(userUtils.getUserDisplayNameByName(Mockito.eq("user2"))).thenReturn("Second user");
   }
 
   @Test


### PR DESCRIPTION
I'm working at organisation where usernames are combined with random numbers and letters assigned to each  employee; I'd like to use the PR Harmony to define groups of people that can accept pr but message  on pr's page with current usernames  is not readable. 
