### PR TITLE
requiredReviewers with lowercase

### DIFF
--- a/src/main/java/com/monitorjbl/plugins/PullRequestApproval.java
+++ b/src/main/java/com/monitorjbl/plugins/PullRequestApproval.java
@@ -34,7 +34,7 @@ public class PullRequestApproval {
     Set<String> missingReviewers = newHashSet();
 
     for(String req : concat(config.getRequiredReviewers(), utils.dereferenceGroups(config.getRequiredReviewerGroups()))) {
-      if(reviewerIsMissing(map.get(req)) && !(submitterIsRequiredReviewer(pr, req) && exactlyEnoughRequiredReviewers())) {
+      if(reviewerIsMissing(map.get(req.toLowerCase())) && !(submitterIsRequiredReviewer(pr, req.toLowerCase()) && exactlyEnoughRequiredReviewers())) {
         missingReviewers.add(req);
       }
     }
@@ -44,15 +44,15 @@ public class PullRequestApproval {
   public Set<String> missingRevieiwersNames(PullRequest pr) {
     Map<String, PullRequestParticipant> map = transformReviewers(pr);
     Set<String> missingReviewers = newHashSet();
-    
+
     for(String req : concat(config.getRequiredReviewers(), utils.dereferenceGroups(config.getRequiredReviewerGroups()))) {
-       if(reviewerIsMissing(map.get(req)) && !(submitterIsRequiredReviewer(pr, req) && exactlyEnoughRequiredReviewers())) {
+       if(reviewerIsMissing(map.get(req.toLowerCase())) && !(submitterIsRequiredReviewer(pr, req.toLowerCase()) && exactlyEnoughRequiredReviewers())) {
 	      missingReviewers.add(utils.getUserDisplayNameByName(req));
 	   }
 	}
 	return missingReviewers;
   }
-  
+
   public Set<String> seenReviewers(PullRequest pr) {
     Set<String> required = newHashSet(concat(config.getRequiredReviewers(), utils.dereferenceGroups(config.getRequiredReviewerGroups())));
     return difference(required, missingRevieiwers(pr));


### PR DESCRIPTION
When using the plugin with Bitbucket 5.1.1 and the following settings 

Number of reviews = 1
Required users = Some users

we had the problem that a Approve by one of the users configured as 'Required users' wasn't sufficient to merge the PullRequest. Debugging showed that  ApplicationUser#getSlug() returned the Username in lowercase but pr-harmony was reading them from the configuration using camel case. Converting the username to lowercase before validating fixed the problem...

Probably there are more places in the plugin code which have to be adjusted accordingly but this change was sufficient for our needs.